### PR TITLE
Add return type to M6WebStatsdBundle::getContainer

### DIFF
--- a/src/M6WebStatsdBundle.php
+++ b/src/M6WebStatsdBundle.php
@@ -17,7 +17,7 @@ class M6WebStatsdBundle extends Bundle
      *
      * @return M6WebStatsdExtension|ExtensionInterface
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $this->extension = new M6WebStatsdExtension();


### PR DESCRIPTION
Fixes `Compile Error: Declaration of M6Web\Bundle\StatsdBundle\M6WebStatsdBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface`