### PR TITLE
fix: cast the replaced value as string

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -187,7 +187,7 @@ class Client extends BaseClient
         if ((preg_match_all('/<([^>]*)>/', $string, $matches) > 0) and ($this->propertyAccessor !== null)) {
             $tokens = $matches[1];
             foreach ($tokens as $token) {
-                $value = $this->propertyAccessor->getValue($event, $token);
+                $value = (string) $this->propertyAccessor->getValue($event, $token);
                 $string = str_replace('<'.$token.'>', $value, $string);
             }
         }


### PR DESCRIPTION
On PHP8.1 when a value is an object, str_replace failed because of the type checking. 

As a solution, we can cast the value returned by the propertyAccessor.  